### PR TITLE
Changed  to  to fix variable naming error

### DIFF
--- a/webclient/src/dc_managers/dc_account_manager.js
+++ b/webclient/src/dc_managers/dc_account_manager.js
@@ -41,7 +41,7 @@ export default class DAppChainAccountManager {
       new Address(client.chainId, LocalAddress.fromPublicKey(publicKey))
     )
 
-    const ethCoin = await Contracts.EthCoin.createAsync(
+    const ethCoin = await Contracts.Coin.createAsync(
       client,
       new Address(client.chainId, LocalAddress.fromPublicKey(publicKey))
     )


### PR DESCRIPTION
I was getting this error: 
```
bundle.js:133428 Uncaught (in promise) TypeError: Cannot read property 'createAsync' of undefined
    at Function.createAsync (bundle.js:133428)
```
which stopped the application from loading properly.

I console log'd `Contracts` and saw that `Coin` was a contract, but not `EthCoin`.  I changed the name in my code to `Coin`, the error went away, and I was able to load the application at 8080 correctly.

![screen shot 2018-08-31 at 10 45 00 am](https://user-images.githubusercontent.com/34707/44924316-8bb86680-ad10-11e8-9b2a-5d3cad440fb1.png)
